### PR TITLE
Añadir BTN_MVT como capa rápida Maplibre

### DIFF
--- a/api-ign-js/package.json
+++ b/api-ign-js/package.json
@@ -47,6 +47,7 @@
     "yargs": "^12.0.1"
   },
   "dependencies": {
+    "@geoblocks/ol-maplibre-layer": "1.0.0",
     "@handlebars/allow-prototype-access": "^1.0.5",
     "canvas": "^2.5.0",
     "chroma-js": "^1.3.7",
@@ -55,14 +56,14 @@
     "handlebars": "^4.1.2",
     "jsdoc": "^3.6.3",
     "jsts": "^2.0.2",
+    "maplibre-gl": "4.3.2",
+    "npm": "^10.9.0",
     "ol": "8.1",
     "ol-mapbox-style": "^6.3.2",
     "pako": "^1.0.11",
     "proj4": "^2.4.4",
     "shpjs": "^3.4.3",
-    "sql.js": "1.8.0",
-    "@geoblocks/ol-maplibre-layer": "1.0.0",
-    "maplibre-gl": "4.3.2"
+    "sql.js": "1.8.0"
   },
   "overrides": {
     "webpack": "5.88.2",

--- a/api-ign-js/src/facade/js/mapea.js
+++ b/api-ign-js/src/facade/js/mapea.js
@@ -10,6 +10,7 @@ import Map from 'M/Map';
 import WFS from 'M/layer/WFS';
 import TMS from 'M/layer/TMS';
 import WMTS from 'M/layer/WMTS';
+import MapLibre from 'M/layer/MapLibre';
 import Point from 'M/style/Point';
 import 'assets/css/ign';
 import { isUndefined, isNullOrEmpty } from './util/Utils';
@@ -191,6 +192,18 @@ let quickLayers = () => {
         },
       }),
     }),
+    BTN_Completa_MapLibre: new MapLibre({
+      url: 'https://vt-btn.idee.es/files/styles/BTN_Completa.json',
+      name: 'BTN_Completa',
+      legend: 'BTN Completa',
+      extract: true,
+      attribution: {
+        name: 'BTN Completa',
+        description: '<p><b>IDEE</b>: <a style="color: #0000FF" href="https://www.scne.es" target="_blank">SCNE</a></p>'
+      },
+    },{
+      disableBackgroundColor: false,
+    })
   };
 };
 

--- a/api-ign-js/test/development/CP-0002-layers/CP-023.html
+++ b/api-ign-js/test/development/CP-0002-layers/CP-023.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="mapea" content="yes">
+
+    <title>BTN_MVT</title>
+    <style rel="stylesheet">
+      html,body{margin:0;padding:0;height:100%;overflow:auto;}
+    </style>
+  </head>
+
+  <body>
+    <div id="map" class="map"></div>
+    <script src="/config.js" charset="utf-8"></script>
+    <script src="/CP-0002-layers/CP-023.js" charset="utf-8"></script>
+  </body>
+</html>

--- a/api-ign-js/test/development/CP-0002-layers/CP-023.js
+++ b/api-ign-js/test/development/CP-0002-layers/CP-023.js
@@ -1,0 +1,12 @@
+import { map as Mmap } from 'M/mapea';
+// import  addQuickLayers from '../../../src/facade/js/mapea';
+
+
+
+const mapa = Mmap({
+  container: 'map',
+});
+
+window.mapa = mapa;
+// mapa.addLayers('QUICK*BTN_Completa_MapLibre')
+mapa.addQuickLayers('UnidadesAdministrativas_MVT')


### PR DESCRIPTION
Incorporación de capa rápida Maplibre, con los datos del servicio teselado vectorial de BTN